### PR TITLE
Patch to support old browsers

### DIFF
--- a/huebee.js
+++ b/huebee.js
@@ -578,7 +578,7 @@ function getSwatch( color ) {
   proxyCtx.fillStyle = '#010203'; // reset value
   proxyCtx.fillStyle = color;
   proxyCtx.fillRect( 0, 0, 1, 1 );
-  var imageData = [].slice.call(proxyCtx.getImageData( 0, 0, 1, 1 ).data);
+  var imageData = Array.prototype.slice.call( proxyCtx.getImageData( 0, 0, 1, 1 ).data );
   if ( imageData.join(',') == '1,2,3,255' ) {
     // invalid color
     return;

--- a/huebee.js
+++ b/huebee.js
@@ -578,7 +578,7 @@ function getSwatch( color ) {
   proxyCtx.fillStyle = '#010203'; // reset value
   proxyCtx.fillStyle = color;
   proxyCtx.fillRect( 0, 0, 1, 1 );
-  var imageData = proxyCtx.getImageData( 0, 0, 1, 1 ).data;
+  var imageData = [].slice.call(proxyCtx.getImageData( 0, 0, 1, 1 ).data);
   if ( imageData.join(',') == '1,2,3,255' ) {
     // invalid color
     return;


### PR DESCRIPTION
Now '_imageData_' is an ordinary _Array_ instead of a _Uint8Array_. This makes it possible to use Huebee color picker in older browsers that don't support ECMAScript 6 (IE11-, Android 5.1- et al.)