### PR TITLE
Offset override options for Huebee

### DIFF
--- a/huebee.js
+++ b/huebee.js
@@ -340,10 +340,11 @@ proto.updateSizes = function() {
   var hues = this.options.hues;
   var shades = this.options.shades;
   var sats = this.options.saturations;
+  var cursorOffsetWidth = this.options.cursorOffsetWidth || this.cursor.offsetWidth;
 
   this.cursorBorder = parseInt( getComputedStyle( this.cursor ).borderTopWidth, 10 );
-  this.gridSize = Math.round( this.cursor.offsetWidth - this.cursorBorder*2 );
-  this.canvasOffset = {
+  this.gridSize = Math.round( cursorOffsetWidth - this.cursorBorder*2 );
+  this.canvasOffset = this.options.canvasOffset || {
     x: this.canvas.offsetLeft,
     y: this.canvas.offsetTop,
   };


### PR DESCRIPTION
When using Huebee with `staticOpen`, inside an element that has zero width / height on page load (e.g. in a Bootstrap dropdown), Huebee fails to render, because `cursor.offsetWidth` and `canvas.offsetLeft` / `canvas.offsetTop` are all 0.

In this case, being able to manually tell Huebee what these offset values should be, via options, allows it to render properly. E.g. with this change, and when passing options of `{"staticOpen": true, "cursorOffsetWidth": 21, "canvasOffset": {"x": 10, "y": 10}}`, Huebee renders for me inside a Bootstrap dropdown that's hidden until a menu item is clicked on.