### PR TITLE
Make sure to initialize proxy canvas before use

### DIFF
--- a/huebee.js
+++ b/huebee.js
@@ -576,11 +576,21 @@ Huebee.data = function( elem ) {
 // -------------------------- getSwatch -------------------------- //
 
 // proxy canvas used to check colors
-var proxyCanvas = document.createElement('canvas');
-proxyCanvas.width = proxyCanvas.height = 1;
-var proxyCtx = proxyCanvas.getContext('2d');
+var proxyCtx;
+
+function initProxyCtxIfNeeded() {
+  // return early when proxy canvas is already initialized.
+  if ( proxyCtx ) {
+    return;
+  }
+
+  var proxyCanvas = document.createElement('canvas');
+  proxyCanvas.width = proxyCanvas.height = 1;
+  proxyCtx = proxyCanvas.getContext('2d');
+}
 
 function getSwatch( color ) {
+  initProxyCtxIfNeeded();
   // check that color value is valid
   proxyCtx.clearRect( 0, 0, 1, 1 );
   proxyCtx.fillStyle = '#010203'; // reset value

--- a/test/site/index.html
+++ b/test/site/index.html
@@ -27,8 +27,8 @@
 
   <script src="../../node_modules/ev-emitter/ev-emitter.js"></script>
   <script src="../../node_modules/unipointer/unipointer.js"></script>
-  <script src="../../huebee.js"></script>
-  <script src="helpers.js"></script>
+  <script src="../../huebee.js" defer="defer"></script>
+  <script src="helpers.js" defer="defer"></script>
 
   <!-- 
   <script src="unit/static-open.js"></script>


### PR DESCRIPTION
Hi! I've got an error with `data-huebee` elements (see image below):

![DevTools](https://user-images.githubusercontent.com/47137677/90129705-1979a900-dda4-11ea-941c-09716b6aba2d.png)

Looks like proxy canvas is not initialized by the time to use it where document is ready and HueBee runs afterwards.

What I did:

- Use deferred-load to test this.
- Initialize proxy canvas whenever we need it.

Thank you in advance.